### PR TITLE
Avoid segfault on loading images

### DIFF
--- a/ThumbnailSequence.cpp
+++ b/ThumbnailSequence.cpp
@@ -1560,7 +1560,7 @@ ThumbnailSequence::CompositeItem::CompositeItem(
 bool
 ThumbnailSequence::CompositeItem::incompleteThumbnail() const
 {
-	return dynamic_cast<IncompleteThumbnail*>(m_pThumb) != 0;
+	return m_pThumb == 0 && dynamic_cast<IncompleteThumbnail*>(m_pThumb) != 0;
 }
 
 void


### PR DESCRIPTION
On FreeBSD the program crashes immediately.
Please allow posting issues, as this one would have been much easier
