### PR TITLE
Ignore the output of the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,23 @@ CMakeFiles
 *.h.moc
 build/
 *~
+*_automoc.cpp
+moc_*cpp
+
+# Individual files
+.version.h
+adiff_tests
+config.h
+generic_tests
+imageproc_tests
+qrc_resources.cpp
+resources/resources.qrc.depends
+spfit_tests
+update_translations_crashreporter.pro
+update_translations_scantailor.pro
+
+# The finished program
+scantailor
+scantailor-cli
+scantailor-cli.exe
+scantailor.exe


### PR DESCRIPTION
Hi.
I just now found your new work on ScanTailor. Thanks for all the effort.

I did open a few PRs on the main ScanTailor repo, and noted that at leas some of them would be useful for this version as well.
Here is the first one. This adds the files created by the build process to the `.gitignore` file, so they don’t clutter up your `git status` view.
