### PR TITLE
Qt5: fix path to lupdate binary

### DIFF
--- a/cmake/UpdateTranslations.cmake
+++ b/cmake/UpdateTranslations.cmake
@@ -90,7 +90,7 @@ MACRO(UPDATE_TRANSLATIONS_TARGET _target) #, _sets
 	SET(_commands "")
 	FOREACH(_set ${ARGN})
 		LIST(
-			APPEND _commands COMMAND "${QT_LUPDATE_EXECUTABLE}" -locations absolute
+			APPEND _commands COMMAND "${Qt5_LUPDATE_EXECUTABLE}" -locations absolute
 			-pro "${CMAKE_BINARY_DIR}/update_translations_${_set}.pro"
 		)
 	ENDFOREACH()


### PR DESCRIPTION
It seems that ${Qt5_LUPDATE_EXECUTABLE} is required instead of ${QT_LUPDATE_EXECUTABLE} for Qt5 compatibility