### PR TITLE
Fix detection of second chance components

### DIFF
--- a/Despeckle.cpp
+++ b/Despeckle.cpp
@@ -822,7 +822,10 @@ Despeckle::despeckleInPlace(
 	
 	bool have_anchored_to_small_but_not_big = false;
 	BOOST_FOREACH(Component const& comp, components) {
-		have_anchored_to_small_but_not_big = comp.anchoredToSmallButNotBig();
+		if (comp.anchoredToSmallButNotBig()) {
+			have_anchored_to_small_but_not_big = true;
+			break;
+		}
 	}
 	
 	if (have_anchored_to_small_but_not_big) {


### PR DESCRIPTION
That seems to be a bug. I've tested and found that there are pages when `have_anchored_to_small_but_not_big` got true but then was reset to false. After the proposed fix the despeckle results are more accurate:
![3](https://user-images.githubusercontent.com/5746456/60911101-1c45c880-a28b-11e9-9053-899d2f4be711.png)
