### PR TITLE
Fix compilation with GCC 10 and libboost 1.74

### DIFF
--- a/filters/deskew/Filter.cpp
+++ b/filters/deskew/Filter.cpp
@@ -83,7 +83,7 @@ Filter::saveSettings(ProjectWriter const& writer, QDomDocument& doc) const
 	
 	QDomElement filter_el(doc.createElement("deskew"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
 			this, boost::ref(doc), var(filter_el), _1, _2
 		)

--- a/filters/fix_orientation/Filter.cpp
+++ b/filters/fix_orientation/Filter.cpp
@@ -98,7 +98,7 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("fix-orientation"));
 	writer.enumImages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writeImageSettings,
 			this, boost::ref(doc), var(filter_el), _1, _2
 		)

--- a/filters/output/ChangeDewarpingDialog.cpp
+++ b/filters/output/ChangeDewarpingDialog.cpp
@@ -22,6 +22,7 @@
 #include "QtSignalForwarder.h"
 #include <boost/function.hpp>
 #include <boost/lambda/lambda.hpp>
+#include <QButtonGroup>
 
 namespace output
 {

--- a/filters/output/Filter.cpp
+++ b/filters/output/Filter.cpp
@@ -35,6 +35,7 @@
 #include <QDomDocument>
 #include <QDomElement>
 #include <memory>
+#include <QButtonGroup>
 
 #include "CommandLine.h"
 #include "ImageViewTab.h"
@@ -91,7 +92,7 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("output"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
 			this, boost::ref(doc), var(filter_el), _1, _2
 		)

--- a/filters/output/OutputGenerator.cpp
+++ b/filters/output/OutputGenerator.cpp
@@ -85,6 +85,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdint.h>
+#include <QPainterPath>
 
 using namespace imageproc;
 using namespace dewarping;

--- a/filters/page_layout/Filter.cpp
+++ b/filters/page_layout/Filter.cpp
@@ -134,7 +134,7 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("page-layout"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
 			this, boost::ref(doc), var(filter_el), _1, _2
 		)

--- a/filters/page_layout/ImageView.cpp
+++ b/filters/page_layout/ImageView.cpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <math.h>
 #include <assert.h>
+#include <QPainterPath>
 
 using namespace imageproc;
 

--- a/filters/page_split/Filter.cpp
+++ b/filters/page_split/Filter.cpp
@@ -108,7 +108,7 @@ Filter::saveSettings(
 	);
 	
 	writer.enumImages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writeImageSettings,
 			this, boost::ref(doc), var(filter_el), _1, _2
 		)

--- a/filters/page_split/OptionsWidget.cpp
+++ b/filters/page_split/OptionsWidget.cpp
@@ -29,6 +29,7 @@
 #include <QPixmap>
 #include <boost/foreach.hpp>
 #include <assert.h>
+#include <QButtonGroup>
 
 namespace page_split
 {

--- a/filters/select_content/Filter.cpp
+++ b/filters/select_content/Filter.cpp
@@ -117,7 +117,7 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("select-content"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
 			this, boost::ref(doc), var(filter_el), _1, _2
 		)

--- a/math/MatrixCalc.h
+++ b/math/MatrixCalc.h
@@ -103,10 +103,10 @@ public:
 	Mat operator-() const;
 
 	T const* rawData() const { return data; }
-private:
 	Mat(AbstractAllocator<T>* alloc, T const* data, int rows, int cols)
 		: alloc(alloc), data(data), rows(rows), cols(cols) {}
 
+private:
 	AbstractAllocator<T>* alloc;
 	T const* data;
 	int rows;

--- a/zones/ZoneContextMenuInteraction.cpp
+++ b/zones/ZoneContextMenuInteraction.cpp
@@ -39,6 +39,7 @@
 #include <boost/ref.hpp>
 #include <vector>
 #include <assert.h>
+#include <QPainterPath>
 
 class ZoneContextMenuInteraction::OrderByArea
 {


### PR DESCRIPTION
Fix compiling errors:

scantailor/math/MatrixCalc.h:141:10: error: calling a private constructor of class 'mcalc::Mat<double>'

zones/ZoneContextMenuInteraction.cpp:92:16: error: variable has incomplete type 'QPainterPath'
and
/usr/include/boost/bind/bind.hpp:531:9: error: no matching function for call to object of type 'boost::_mfi::cmf4<void, page_split::Filter, QDomDocument &, QDomElement &, const ImageId &, int>'
by writing boost::lambda::bind explicitly.